### PR TITLE
Schedule poll

### DIFF
--- a/src/main/java/no/haugalandplus/val/dto/PollDTO.java
+++ b/src/main/java/no/haugalandplus/val/dto/PollDTO.java
@@ -18,4 +18,5 @@ public class PollDTO {
     private Date endTime;
     private PollStatusEnum status;
     private List<ChoiceDTO> choices;
+    private Boolean hasUserVoted;
 }

--- a/src/main/java/no/haugalandplus/val/dto/StartPollDTO.java
+++ b/src/main/java/no/haugalandplus/val/dto/StartPollDTO.java
@@ -1,0 +1,13 @@
+package no.haugalandplus.val.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Getter
+@Setter
+public class StartPollDTO {
+    private Date startTime;
+    private Date endTime;
+}

--- a/src/main/java/no/haugalandplus/val/repository/VoteRepository.java
+++ b/src/main/java/no/haugalandplus/val/repository/VoteRepository.java
@@ -10,8 +10,11 @@ import org.springframework.data.repository.query.Param;
 
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 
-    Boolean existsByVoterAndChoice(User voter, Choice poll);
+    @Query("select (count(v) > 0) from Vote v where v.choice.poll = :poll and v.voter = :voter")
+    Boolean existsByVoterAndPoll(@Param("voter") User voter, @Param("poll") Poll poll);
 
     @Query("select coalesce(sum(v.voteCount), 0) from Vote v where v.choice.ChoiceId = :choiceId")
     Long sumOfVotesByChoiceId(@Param("choiceId") Long choiceId);
+
+    void deleteAllByChoice(Choice choice);
 }

--- a/src/main/java/no/haugalandplus/val/rest/PollController.java
+++ b/src/main/java/no/haugalandplus/val/rest/PollController.java
@@ -1,6 +1,7 @@
 package no.haugalandplus.val.rest;
 
 import no.haugalandplus.val.dto.PollDTO;
+import no.haugalandplus.val.dto.StartPollDTO;
 import no.haugalandplus.val.dto.VoteDTO;
 import no.haugalandplus.val.service.LiveService;
 import no.haugalandplus.val.service.PollService;
@@ -62,8 +63,8 @@ public class PollController {
 
     @PostMapping("/{id}/start")
     @PreAuthorize("@authService.ownsPoll(#id)")
-    public PollDTO startPoll(@PathVariable Long id) {
-        return liveService.startPoll(id);
+    public PollDTO startPoll(@PathVariable Long id, @RequestBody StartPollDTO startPollDTO) {
+        return liveService.startPoll(id, startPollDTO);
     }
 
     @PostMapping("/{id}/end")

--- a/src/main/java/no/haugalandplus/val/service/AuthService.java
+++ b/src/main/java/no/haugalandplus/val/service/AuthService.java
@@ -54,7 +54,7 @@ public class AuthService extends ServiceUtils {
                 return false;
             }
             if (poll.isNeedLogin()) {
-                return isLoggedIn() && !voteRepository.existsByVoterAndChoice(getCurrentUser(), choice);
+                return isLoggedIn() && !voteRepository.existsByVoterAndPoll(getCurrentUser(), poll);
             }
             return true;
         } catch (Exception e) {

--- a/src/main/java/no/haugalandplus/val/service/ServiceUtils.java
+++ b/src/main/java/no/haugalandplus/val/service/ServiceUtils.java
@@ -12,15 +12,14 @@ public class ServiceUtils {
         if (auth == null) {
             return null;
         }
-        return (User) auth.getPrincipal();
+        if (auth.getPrincipal() instanceof User user) {
+            return user;
+        }
+        return null;
     }
 
     protected User getCurrentUser() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null) {
-            throw new AccessDeniedException("Not logged in");
-        }
-        User user = (User) auth.getPrincipal();
+        User user = getCurrentUserSafe();
         if (user == null) {
             throw new AccessDeniedException("Not logged in");
         }

--- a/src/test/java/no/haugalandplus/val/service/PollServiceMock.java
+++ b/src/test/java/no/haugalandplus/val/service/PollServiceMock.java
@@ -1,0 +1,32 @@
+package no.haugalandplus.val.service;
+
+import no.haugalandplus.val.repository.ChoiceRepository;
+import no.haugalandplus.val.repository.PollRepository;
+import no.haugalandplus.val.repository.VoteRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@Service
+public class PollServiceMock extends PollService {
+
+    public PollServiceMock(PollRepository pollRepository, ModelMapper modelMapper, VoteRepository voteRepository, ChoiceRepository choiceRepository, IoTService ioTService) {
+        super(pollRepository, modelMapper, voteRepository, choiceRepository, ioTService);
+    }
+
+    private Date currentDate;
+
+    @Override
+    protected Date clock() {
+        if (currentDate != null) {
+            return currentDate;
+        } else {
+            return super.clock();
+        }
+    }
+
+    public void setCurrentDate(Date currentDate) {
+        this.currentDate = currentDate;
+    }
+}


### PR DESCRIPTION
- Poll can be re-started. All previous results are deleted `POST /polls/id/start`
- More support for scheduled poll. When sending to `POST /polls/id/start` you can send an object 
    `{ "startTime": Date, "endTime": Date }`. When startTime is set to null, it starts now.
- PollDTO now has `hasUserVoted` in it.